### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,23 +19,23 @@
     "url": "http://hughsk.io/"
   },
   "dependencies": {
-    "a-big-triangle": "0.0.0",
+    "a-big-triangle": "1.0.2",
     "canvas-pixels": "0.0.0",
-    "gl-fbo": "^1.1.0",
-    "glslify": "^1.4.0"
+    "gl-fbo": "^2.0.5",
+    "glslify": "^2.3.1"
   },
   "devDependencies": {
-    "beefy": "^1.1.0",
-    "browserify": "^4.1.10",
-    "canvas-fit": "0.0.0",
-    "canvas-orbit-camera": "0.0.0",
+    "beefy": "^2.1.5",
+    "browserify": "^12.0.1",
+    "canvas-fit": "1.5.0",
+    "canvas-orbit-camera": "1.0.2",
     "domify": "^1.2.2",
-    "gl-clear": "0.0.0",
+    "gl-clear": "2.0.0",
     "gl-context": "^0.1.0",
-    "gl-geometry": "0.0.0",
+    "gl-geometry": "1.2.0",
     "gl-matrix": "^2.1.0",
-    "icosphere": "0.0.0",
-    "normals": "^0.1.0"
+    "icosphere": "1.0.0",
+    "normals": "^1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello stackgl,

I was trying out shader-school and ran into an [installation error](https://github.com/stackgl/shader-school/issues/145) that involved esprima-six:

```
npm ERR! code E404

npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/esprima-six
npm ERR! 404 
npm ERR! 404 'esprima-six' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'astw'
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

Going through the npm-debug log, it looked like this module's `glslify` dependency was the cause of the problem, specifically glslify version [1.4.0](https://github.com/stackgl/glslify/blob/v1.4.0/package.json#L41) which has a dependency on sleuth version 0.0.0, which depends on astw 0.1.0 [which depends on esprima-six](https://github.com/substack/astw/blob/0.1.0/package.json#L7).

Bumping the version of glslify from `^1.4.0` to `^2.3.1` solved the installation error, and I bumped the other dependencies for good measure. I'm not familiar with gl, so I'm not sure if this dependency bump breaks anything, but just wanted to give you a heads-up that this is causing downstream headaches. 

Maybe the real solution is to talk with the maintainers of esprima-six.

cc/ @substack @hughsk @chrisdickinson @mikolalysenko 
