### PR TITLE
Update module to reflect new glslify and fbo functions. Fix example.

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -9,6 +9,7 @@ var fitter         = require('canvas-fit')
 var icosphere      = require('icosphere')
 var normals        = require('normals')
 var glslify        = require('glslify')
+var glShader       = require('gl-shader')
 var domify         = require('domify')
 var comparator     = require('../')
 
@@ -41,23 +42,19 @@ slide.style.right = '32px'
 camera.distance = 3
 compare.mode = 'diff'
 
-var actualShader = glslify({
-    vert: './reverse.vert'
-  , frag: './actual.frag'
-})(gl)
+var actualShader = glShader(gl
+  , glslify('./reverse.vert')
+  , glslify('./actual.frag')
+)
 
-var expectedShader = glslify({
-    vert: './basic.vert'
-  , frag: './expected.frag'
-})(gl)
+var expectedShader = glShader(gl
+  , glslify('./basic.vert')
+  , glslify('./expected.frag')
+)
 
 window.addEventListener('resize', resize(), false)
 function resize() {
   fit()
-
-  compare.actual.fbo.shape =
-  compare.expected.fbo.shape = [canvas.height, canvas.width]
-
   return resize
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var triangle  = require('a-big-triangle')
 var pixels    = require('canvas-pixels')
 var glslify   = require('glslify')
+var glShader  = require('gl-shader')
 var createFBO = require('gl-fbo')
 
 module.exports = Compare
@@ -13,22 +14,22 @@ function Compare(gl, actual, expected) {
   this.expected = expected
   this._mode = modes[0]
   this.shaders = {
-    diff: glslify({
-        vert: './shaders/full.vert'
-      , frag: './shaders/diff.frag'
-    })(gl),
-    onion: glslify({
-        vert: './shaders/full.vert'
-      , frag: './shaders/onion.frag'
-    })(gl),
-    slide: glslify({
-        vert: './shaders/full.vert'
-      , frag: './shaders/slide.frag'
-    })(gl)
+    diff: glShader(gl,
+      glslify('./shaders/full.vert')
+      , glslify('./shaders/diff.frag')
+    ),
+    onion: glShader(gl
+      , glslify('./shaders/full.vert')
+      , glslify('./shaders/onion.frag')
+    ),
+    slide: glShader(gl
+      , glslify('./shaders/full.vert')
+      , glslify('./shaders/slide.frag')
+    )
   }
 
-  this.actual.fbo = createFBO(gl, 512, 512)
-  this.expected.fbo = createFBO(gl, 512, 512)
+  this.actual.fbo = createFBO(gl, [512, 512])
+  this.expected.fbo = createFBO(gl, [512, 512])
 
   this.diff = { amount: 0.1 }
   this.slide = { amount: 0.5 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "a-big-triangle": "1.0.2",
     "canvas-pixels": "0.0.0",
     "gl-fbo": "^2.0.5",
+    "gl-shader": "^4.1.0",
     "glslify": "^2.3.1"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "domify": "^1.2.2",
     "gl-clear": "2.0.0",
     "gl-context": "^0.1.0",
+    "glsl-dither": "^1.0.1",
     "gl-geometry": "1.2.0",
     "gl-matrix": "^2.1.0",
     "icosphere": "1.0.0",


### PR DESCRIPTION
This fixes a few issues introduced by #1 when updating the modules. I believe that this now works (verified by rendering out the fbos to textures and doing a mental diff), but it would probably be valuable to check and make sure the example output is still good. This is part 1 of the PRs required to get shader-school and webgl-workshop working again after esprima-six was removed.
